### PR TITLE
feat: ランキングUI実装 + Critical修正

### DIFF
--- a/src/app/api/stocks/route.ts
+++ b/src/app/api/stocks/route.ts
@@ -109,17 +109,17 @@ export async function GET(request: NextRequest) {
       take: params.limit,
     });
 
-    // レスポンスを整形
+    // レスポンスを整形（0値を正しく扱うため != null でチェック）
     const data: StockItem[] = stocks.map((stock) => ({
       code: stock.code,
       name: stock.name,
       sector: stock.sector,
-      price: stock.price ? Number(stock.price) : null,
-      dividendYield: stock.dividendYield ? Number(stock.dividendYield) : null,
-      dividend: stock.dividend ? Number(stock.dividend) : null,
-      marketCap: stock.marketCap ? Number(stock.marketCap) : null,
-      per: stock.per ? Number(stock.per) : null,
-      pbr: stock.pbr ? Number(stock.pbr) : null,
+      price: stock.price != null ? Number(stock.price) : null,
+      dividendYield: stock.dividendYield != null ? Number(stock.dividendYield) : null,
+      dividend: stock.dividend != null ? Number(stock.dividend) : null,
+      marketCap: stock.marketCap != null ? Number(stock.marketCap) : null,
+      per: stock.per != null ? Number(stock.per) : null,
+      pbr: stock.pbr != null ? Number(stock.pbr) : null,
       isNikkei225: stock.isNikkei225,
       updatedAt: stock.updatedAt.toISOString(),
     }));

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -12,6 +12,11 @@ export async function POST(request: NextRequest) {
     const authHeader = request.headers.get("authorization");
     const cronSecret = process.env.CRON_SECRET;
 
+    // 本番環境ではCRON_SECRET必須
+    if (process.env.NODE_ENV === "production" && !cronSecret) {
+      throw ApiError.internal("CRON_SECRET is not configured");
+    }
+
     if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
       throw ApiError.unauthorized("Invalid authorization");
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,17 @@
-import { Button } from "@/components/ui/button";
-import Link from "next/link";
+import { StockRankingTable } from "@/components/stock-ranking-table";
 
 export default function Home() {
   return (
-    <div className="container flex flex-col items-center justify-center py-24">
-      <div className="flex flex-col items-center gap-8 max-w-2xl text-center">
-        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">配当みっけ</h1>
-        <p className="text-lg text-muted-foreground">
-          日本株の配当利回りランキングを提供する配当株情報サービス
-        </p>
-        <Button asChild size="lg">
-          <Link href="/ranking">ランキングを見る</Link>
-        </Button>
+    <div className="container py-6 md:py-8">
+      <div className="space-y-6">
+        {/* ヘッダー */}
+        <div className="text-center space-y-2">
+          <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">配当みっけ</h1>
+          <p className="text-muted-foreground">日本株の配当利回りランキング</p>
+        </div>
+
+        {/* ランキングテーブル */}
+        <StockRankingTable />
       </div>
     </div>
   );

--- a/src/components/stock-filters.tsx
+++ b/src/components/stock-filters.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { SortField, SortOrder, StockFilters } from "@/types/stock";
+
+interface StockFiltersProps {
+  filters: StockFilters;
+  onFiltersChange: (filters: StockFilters) => void;
+}
+
+/** ソートオプションの定義 */
+const SORT_OPTIONS: { value: SortField; label: string }[] = [
+  { value: "dividendYield", label: "配当利回り" },
+  { value: "price", label: "株価" },
+  { value: "marketCap", label: "時価総額" },
+  { value: "per", label: "PER" },
+  { value: "pbr", label: "PBR" },
+  { value: "name", label: "銘柄名" },
+  { value: "code", label: "証券コード" },
+];
+
+/**
+ * 銘柄フィルタパネル
+ * ソート条件と日経225フィルタを提供
+ */
+export function StockFiltersPanel({ filters, onFiltersChange }: StockFiltersProps) {
+  const handleSortChange = (value: SortField) => {
+    onFiltersChange({ ...filters, sort: value });
+  };
+
+  const handleOrderChange = (value: SortOrder) => {
+    onFiltersChange({ ...filters, order: value });
+  };
+
+  const handleNikkei225Change = (value: string) => {
+    onFiltersChange({ ...filters, nikkei225Only: value === "true" });
+  };
+
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          {/* ソート設定 */}
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+            <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">
+              並び替え
+            </span>
+            <div className="flex gap-2">
+              <Select value={filters.sort} onValueChange={handleSortChange}>
+                <SelectTrigger className="w-[140px]">
+                  <SelectValue placeholder="項目を選択" />
+                </SelectTrigger>
+                <SelectContent>
+                  {SORT_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Select value={filters.order} onValueChange={handleOrderChange}>
+                <SelectTrigger className="w-[100px]">
+                  <SelectValue placeholder="順序" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="desc">降順</SelectItem>
+                  <SelectItem value="asc">昇順</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {/* 日経225フィルタ */}
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-muted-foreground whitespace-nowrap">
+              対象
+            </span>
+            <Select
+              value={filters.nikkei225Only ? "true" : "false"}
+              onValueChange={handleNikkei225Change}
+            >
+              <SelectTrigger className="w-[140px]">
+                <SelectValue placeholder="対象を選択" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="false">全銘柄</SelectItem>
+                <SelectItem value="true">日経225のみ</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/stock-ranking-table.tsx
+++ b/src/components/stock-ranking-table.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+import { StockFiltersPanel } from "@/components/stock-filters";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { Stock, StockFilters as StockFiltersType, StocksResponse } from "@/types/stock";
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * 数値を日本語表記でフォーマット（億、万）
+ */
+function formatMarketCap(value: number | null): string {
+  if (value === null) return "-";
+  // value は百万円単位
+  if (value >= 1000) {
+    return `${(value / 10000).toFixed(1)}兆円`;
+  }
+  if (value >= 100) {
+    return `${(value / 100).toFixed(0)}億円`;
+  }
+  return `${value.toFixed(0)}百万円`;
+}
+
+/**
+ * 数値を通貨形式でフォーマット
+ */
+function formatPrice(value: number | null): string {
+  if (value === null) return "-";
+  return `${value.toLocaleString()}円`;
+}
+
+/**
+ * 配当利回りをフォーマット
+ */
+function formatYield(value: number | null): string {
+  if (value === null) return "-";
+  return `${value.toFixed(2)}%`;
+}
+
+/**
+ * PER/PBRをフォーマット
+ */
+function formatRatio(value: number | null): string {
+  if (value === null) return "-";
+  return value.toFixed(2);
+}
+
+/**
+ * 銘柄ランキングテーブルコンポーネント
+ * /api/stocks からデータを取得し、ランキング形式で表示
+ */
+export function StockRankingTable() {
+  const [stocks, setStocks] = useState<Stock[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [filters, setFilters] = useState<StockFiltersType>({
+    sort: "dividendYield",
+    order: "desc",
+    nikkei225Only: false,
+  });
+
+  const fetchStocks = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const params = new URLSearchParams({
+        sort: filters.sort,
+        order: filters.order,
+        page: page.toString(),
+        limit: "20",
+      });
+
+      if (filters.nikkei225Only) {
+        params.set("nikkei225Only", "true");
+      }
+
+      const response = await fetch(`/api/stocks?${params.toString()}`);
+
+      if (!response.ok) {
+        throw new Error("データの取得に失敗しました");
+      }
+
+      const data: StocksResponse = await response.json();
+      setStocks(data.data);
+      setTotalPages(data.pagination.totalPages);
+      setTotal(data.pagination.total);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "エラーが発生しました");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [filters, page]);
+
+  useEffect(() => {
+    fetchStocks();
+  }, [fetchStocks]);
+
+  // フィルタ変更時はページを1に戻す
+  const handleFiltersChange = (newFilters: StockFiltersType) => {
+    setFilters(newFilters);
+    setPage(1);
+  };
+
+  // ランキング順位を計算
+  const getRank = (index: number): number => {
+    return (page - 1) * 20 + index + 1;
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* フィルタパネル */}
+      <StockFiltersPanel filters={filters} onFiltersChange={handleFiltersChange} />
+
+      {/* テーブル */}
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg">配当利回りランキング</CardTitle>
+            <span className="text-sm text-muted-foreground">
+              {total > 0 ? `全${total.toLocaleString()}件` : ""}
+            </span>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0 sm:p-6 sm:pt-0">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <div className="text-muted-foreground">読み込み中...</div>
+            </div>
+          ) : error ? (
+            <div className="flex flex-col items-center justify-center gap-4 py-12">
+              <div className="text-destructive">{error}</div>
+              <Button variant="outline" onClick={fetchStocks}>
+                再試行
+              </Button>
+            </div>
+          ) : stocks.length === 0 ? (
+            <div className="flex items-center justify-center py-12">
+              <div className="text-muted-foreground">該当する銘柄がありません</div>
+            </div>
+          ) : (
+            <>
+              {/* デスクトップ用テーブル */}
+              <div className="hidden sm:block">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[60px] text-center">順位</TableHead>
+                      <TableHead className="w-[80px]">コード</TableHead>
+                      <TableHead>銘柄名</TableHead>
+                      <TableHead className="text-right">配当利回り</TableHead>
+                      <TableHead className="text-right">株価</TableHead>
+                      <TableHead className="text-right">配当金</TableHead>
+                      <TableHead className="text-right">PER</TableHead>
+                      <TableHead className="text-right">PBR</TableHead>
+                      <TableHead className="text-right">時価総額</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {stocks.map((stock, index) => (
+                      <TableRow key={stock.code}>
+                        <TableCell className="text-center font-medium">{getRank(index)}</TableCell>
+                        <TableCell className="font-mono">{stock.code}</TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            <span className="truncate max-w-[200px]">{stock.name}</span>
+                            {stock.isNikkei225 && (
+                              <Badge variant="secondary" className="shrink-0">
+                                N225
+                              </Badge>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-right font-medium text-primary">
+                          {formatYield(stock.dividendYield)}
+                        </TableCell>
+                        <TableCell className="text-right">{formatPrice(stock.price)}</TableCell>
+                        <TableCell className="text-right">{formatPrice(stock.dividend)}</TableCell>
+                        <TableCell className="text-right">{formatRatio(stock.per)}</TableCell>
+                        <TableCell className="text-right">{formatRatio(stock.pbr)}</TableCell>
+                        <TableCell className="text-right">
+                          {formatMarketCap(stock.marketCap)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+
+              {/* モバイル用カードリスト */}
+              <div className="sm:hidden">
+                <div className="divide-y">
+                  {stocks.map((stock, index) => (
+                    <div key={stock.code} className="p-4 space-y-2">
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="flex items-center gap-2">
+                          <span className="text-lg font-bold text-muted-foreground w-8">
+                            {getRank(index)}
+                          </span>
+                          <div>
+                            <div className="flex items-center gap-2">
+                              <span className="font-mono text-sm text-muted-foreground">
+                                {stock.code}
+                              </span>
+                              {stock.isNikkei225 && (
+                                <Badge variant="secondary" className="text-xs">
+                                  N225
+                                </Badge>
+                              )}
+                            </div>
+                            <div className="font-medium">{stock.name}</div>
+                          </div>
+                        </div>
+                        <div className="text-right">
+                          <div className="text-lg font-bold text-primary">
+                            {formatYield(stock.dividendYield)}
+                          </div>
+                          <div className="text-sm text-muted-foreground">配当利回り</div>
+                        </div>
+                      </div>
+                      <div className="grid grid-cols-3 gap-2 text-sm">
+                        <div>
+                          <div className="text-muted-foreground">株価</div>
+                          <div>{formatPrice(stock.price)}</div>
+                        </div>
+                        <div>
+                          <div className="text-muted-foreground">配当金</div>
+                          <div>{formatPrice(stock.dividend)}</div>
+                        </div>
+                        <div>
+                          <div className="text-muted-foreground">時価総額</div>
+                          <div>{formatMarketCap(stock.marketCap)}</div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </>
+          )}
+
+          {/* ページネーション */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 py-4 border-t">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1 || isLoading}
+              >
+                前へ
+              </Button>
+              <span className="text-sm text-muted-foreground">
+                {page} / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages || isLoading}
+              >
+                次へ
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,33 @@
+import { type VariantProps, cva } from "class-variance-authority";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-xl border bg-card text-card-foreground shadow", className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+  )
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  )
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  )
+);
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  )
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+  )
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+};

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,94 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-auto">
+      <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+    </div>
+  )
+);
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+));
+TableBody.displayName = "TableBody";
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
+    {...props}
+  />
+));
+TableFooter.displayName = "TableFooter";
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption ref={ref} className={cn("mt-4 text-sm text-muted-foreground", className)} {...props} />
+));
+TableCaption.displayName = "TableCaption";
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/src/types/stock.ts
+++ b/src/types/stock.ts
@@ -1,0 +1,64 @@
+/**
+ * 銘柄情報の型定義
+ */
+export interface Stock {
+  /** 証券コード（例: 7203） */
+  code: string;
+  /** 銘柄名 */
+  name: string;
+  /** セクター/業種 */
+  sector: string | null;
+  /** 現在株価 */
+  price: number | null;
+  /** 配当利回り（%） */
+  dividendYield: number | null;
+  /** 年間配当金額 */
+  dividend: number | null;
+  /** 時価総額（百万円） */
+  marketCap: number | null;
+  /** PER（株価収益率） */
+  per: number | null;
+  /** PBR（株価純資産倍率） */
+  pbr: number | null;
+  /** 日経225採用銘柄かどうか */
+  isNikkei225: boolean;
+  /** 更新日時 */
+  updatedAt: string;
+}
+
+/**
+ * APIレスポンスのページネーション情報
+ */
+export interface Pagination {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+/**
+ * /api/stocks のレスポンス型
+ */
+export interface StocksResponse {
+  data: Stock[];
+  pagination: Pagination;
+}
+
+/**
+ * ソートフィールドの型
+ */
+export type SortField = "dividendYield" | "price" | "marketCap" | "per" | "pbr" | "name" | "code";
+
+/**
+ * ソート順序の型
+ */
+export type SortOrder = "asc" | "desc";
+
+/**
+ * フィルタ条件の型
+ */
+export interface StockFilters {
+  sort: SortField;
+  order: SortOrder;
+  nikkei225Only: boolean;
+}


### PR DESCRIPTION
## Summary

- 配当利回りランキングUIを実装
- PRレビューで指摘されたCritical問題を修正

## 新規実装

### コンポーネント
- `src/components/stock-ranking-table.tsx` - ランキングテーブル
  - デスクトップ: テーブル表示
  - モバイル: カード表示（レスポンシブ対応）
  - ページネーション機能
- `src/components/stock-filters.tsx` - フィルタパネル
  - ソート項目選択（配当利回り、株価、時価総額等）
  - 日経225のみフィルタ

### 型定義
- `src/types/stock.ts` - Stock, Pagination, StocksResponse

### shadcn/ui
- table, select, card, input, badge

## Critical修正

### sync API認証バイパス修正
本番環境で`CRON_SECRET`未設定時はエラーを返すように修正

### 0値消失バグ修正
`stock.price ?` のfalsy判定を `stock.price != null ?` に修正

## Test plan

- [x] `pnpm test` - 21件パス
- [x] `pnpm build` - ビルド成功
- [ ] ブラウザでランキング表示確認
- [ ] モバイル表示確認

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)